### PR TITLE
Low-level modules should handle NluIntentParsed instead of NluIntent

### DIFF
--- a/rhasspyserver_hermes/__init__.py
+++ b/rhasspyserver_hermes/__init__.py
@@ -44,7 +44,7 @@ from rhasspyhermes.dialogue import DialogueSessionStarted
 from rhasspyhermes.g2p import G2pError, G2pPhonemes, G2pPronounce
 from rhasspyhermes.nlu import (
     NluError,
-    NluIntent,
+    NluIntentParsed,
     NluIntentNotRecognized,
     NluQuery,
     NluTrain,
@@ -416,7 +416,7 @@ class RhasspyCore:
 
     async def recognize_intent(
         self, text: str, intent_filter: typing.Optional[typing.List[str]] = None
-    ) -> typing.Union[NluIntent, NluIntentNotRecognized]:
+    ) -> typing.Union[NluIntentParsed, NluIntentNotRecognized]:
         """Send an NLU query and wait for intent or not recognized"""
         if self.nlu_system == "dummy":
             raise NluException("No intent system configured")
@@ -435,13 +435,13 @@ class RhasspyCore:
                 _, message = yield
 
                 if isinstance(
-                    message, (NluIntent, NluIntentNotRecognized, NluError)
+                    message, (NluIntentParsed, NluIntentNotRecognized, NluError)
                 ) and (message.session_id == nlu_id):
                     return message
 
         messages = [query]
         message_types: typing.List[typing.Type[Message]] = [
-            NluIntent,
+            NluIntentParsed,
             NluIntentNotRecognized,
             NluError,
         ]
@@ -457,7 +457,7 @@ class RhasspyCore:
             _LOGGER.error(result)
             raise NluException(result.error)
 
-        assert isinstance(result, (NluIntent, NluIntentNotRecognized)), result
+        assert isinstance(result, (NluIntentParsed, NluIntentNotRecognized)), result
         return result
 
     # -------------------------------------------------------------------------
@@ -964,7 +964,7 @@ class RhasspyCore:
             self.subscribe(
                 HotwordDetected,
                 AsrTextCaptured,
-                NluIntent,
+                NluIntentParsed,
                 NluIntentNotRecognized,
                 AsrAudioCaptured,
                 AudioSummary,
@@ -1084,7 +1084,7 @@ class RhasspyCore:
                     elif isinstance(message, NluError):
                         # NLU service error
                         self.handle_message(topic, message)
-                    elif isinstance(message, NluIntent):
+                    elif isinstance(message, NluIntentParsed):
                         _LOGGER.debug("<- %s", message)
 
                         # Successful intent recognition
@@ -1127,7 +1127,7 @@ class RhasspyCore:
                     # Check for satellite messages.
                     # This ensures that websocket events are reported on the base
                     # station as well as the satellite.
-                    if isinstance(message, (NluIntent, NluIntentNotRecognized)) and (
+                    if isinstance(message, NluIntentNotRecognized) and (
                         site_id in self.satellite_site_ids["intent"]
                     ):
                         # Report satellite message to base websockets

--- a/rhasspyserver_hermes/__main__.py
+++ b/rhasspyserver_hermes/__main__.py
@@ -57,7 +57,7 @@ from rhasspyhermes.audioserver import (
 )
 from rhasspyhermes.base import Message
 from rhasspyhermes.handle import HandleToggleOff, HandleToggleOn
-from rhasspyhermes.nlu import NluError, NluIntent, NluIntentNotRecognized, NluQuery
+from rhasspyhermes.nlu import NluError, NluIntentParsed, NluIntentNotRecognized, NluQuery
 from rhasspyhermes.wake import (
     HotwordDetected,
     HotwordToggleOff,
@@ -843,11 +843,11 @@ async def api_listen_for_command() -> Response:
                 _, message = yield
 
                 if isinstance(
-                    message, (NluIntent, NluIntentNotRecognized, NluError)
+                    message, (NluIntentParsed, NluIntentNotRecognized, NluError)
                 ) and (message.session_id == session_id):
                     return message
 
-        message_types = [NluIntent, NluIntentNotRecognized, NluError]
+        message_types = [NluIntentParsed, NluIntentNotRecognized, NluError]
         messages = [
             AsrStopListening(site_id=core.site_id, session_id=session_id),
             NluQuery(
@@ -870,17 +870,17 @@ async def api_listen_for_command() -> Response:
         if isinstance(nlu_intent, NluError):
             raise RuntimeError(nlu_intent.error)
 
-        assert isinstance(nlu_intent, (NluIntent, NluIntentNotRecognized))
+        assert isinstance(nlu_intent, (NluIntentParsed, NluIntentNotRecognized))
 
         # Add user-defined entities
-        if entity and isinstance(nlu_intent, NluIntent):
+        if entity and isinstance(nlu_intent, NluIntentParsed):
             nlu_intent.slots = nlu_intent.slots or []
             nlu_intent.slots.append(
                 rhasspyhermes.intent.Slot(entity=entity, value={"value": value})
             )
 
         if output_format == "hermes":
-            if isinstance(nlu_intent, NluIntent):
+            if isinstance(nlu_intent, NluIntentParsed):
                 intent_dict = {"type": "intent", "value": nlu_intent.to_dict()}
             else:
                 intent_dict = {
@@ -1962,7 +1962,7 @@ async def api_evaluate() -> Response:
                         _LOGGER.debug("Exceeded total retries (%s)", timeout_retries)
                         raise e
 
-            if not isinstance(nlu_intent, NluIntent):
+            if not isinstance(nlu_intent, NluIntentParsed):
                 _LOGGER.warning("Recognition failed: %s", nlu_intent)
 
                 if stop_on_error:
@@ -1972,7 +1972,7 @@ async def api_evaluate() -> Response:
                     break
 
                 # Empty intent
-                nlu_intent = NluIntent(
+                nlu_intent = NluIntentParsed(
                     input=text_captured.text,
                     intent=rhasspyhermes.intent.Intent(
                         intent_name="", confidence_score=0
@@ -2016,7 +2016,7 @@ async def api_handle_intent():
     """Receive an intent via JSON and publish it."""
     assert core is not None
     intent_dict = await request.json
-    intent = NluIntent.from_dict(intent_dict)
+    intent = NluIntentParsed.from_dict(intent_dict)
     core.publish(intent)
 
     return "OK"
@@ -2240,14 +2240,14 @@ async def api_ws_intent(queue) -> None:
             message = await queue.get()
             if message[0] == "intent":
                 intent = typing.cast(
-                    typing.Union[NluIntent, NluIntentNotRecognized], message[1]
+                    typing.Union[NluIntentParsed, NluIntentParsed, NluIntentNotRecognized], message[1]
                 )
                 intent_dict = intent.to_rhasspy_dict()
 
                 # Add extra info
                 intent_dict["siteId"] = intent.site_id
                 intent_dict["sessionId"] = intent.session_id
-                intent_dict["customData"] = intent.custom_data
+                intent_dict["customData"] = getattr(intent, "custom_data", None)
                 intent_dict["wakewordId"] = getattr(intent, "wakeword_id", None)
                 intent_dict["lang"] = getattr(intent, "lang", None)
 
@@ -2500,7 +2500,7 @@ async def text_to_intent_dict(
     result = await core.recognize_intent(text, intent_filter=intent_filter)
 
     # Add user-defined entities
-    if user_entities and isinstance(result, NluIntent):
+    if user_entities and isinstance(result, NluIntentParsed):
         result.slots = result.slots or []
         for entity, value in user_entities:
             result.slots.append(
@@ -2511,7 +2511,7 @@ async def text_to_intent_dict(
     intent_dict: typing.Dict[str, typing.Any] = {}
 
     if output_format == "hermes":
-        if isinstance(result, NluIntent):
+        if isinstance(result, NluIntentParsed):
             intent_dict = {"type": "intent", "value": result.to_dict()}
         else:
             intent_dict = {"type": "intentNotRecognized", "value": result.to_dict()}


### PR DESCRIPTION
This is one of a series of patches for moving handling of NluIntent messages from the NLU modules to the Dialogue Manager, [according to the Hermes protocol](https://github.com/rhasspy/rhasspy-rasa-nlu-hermes/issues/3).