### PR TITLE
do not set session_id without starting a dialog session

### DIFF
--- a/rhasspyserver_hermes/__init__.py
+++ b/rhasspyserver_hermes/__init__.py
@@ -484,11 +484,7 @@ class RhasspyCore:
 
         nlu_id = str(uuid4())
         query = NluQuery(
-            id=nlu_id,
-            input=text,
-            intent_filter=intent_filter,
-            site_id=self.site_id,
-            session_id=nlu_id,
+            id=nlu_id, input=text, intent_filter=intent_filter, site_id=self.site_id,
         )
 
         def handle_intent():
@@ -497,7 +493,7 @@ class RhasspyCore:
 
                 if isinstance(
                     message, (NluIntent, NluIntentNotRecognized, NluError)
-                ) and (message.session_id == nlu_id):
+                ) and (message.id == nlu_id):
                     return message
 
         messages = [query]


### PR DESCRIPTION
Right now the session_id is set to a nlu_id without starting a dialogue session for it. I think this can be simply removed.