### PR TITLE
Reuse websocket message queues across restarts

### DIFF
--- a/rhasspyserver_hermes/__init__.py
+++ b/rhasspyserver_hermes/__init__.py
@@ -117,6 +117,7 @@ class RhasspyCore:
         certfile: typing.Optional[str] = None,
         keyfile: typing.Optional[str] = None,
         loop: typing.Optional[asyncio.AbstractEventLoop] = None,
+        external_queues: typing.Set[asyncio.Queue] = None,
     ):
         self.loop = loop or asyncio.get_event_loop()
 
@@ -250,7 +251,7 @@ class RhasspyCore:
         self.handler_queues: typing.Dict[str, asyncio.Queue] = {}
 
         # External message queues
-        self.message_queues: typing.Set[asyncio.Queue] = set()
+        self.message_queues: typing.Set[asyncio.Queue] = external_queues
 
         # Cached wake word IDs for sessions
         # Holds last voice command

--- a/rhasspyserver_hermes/__main__.py
+++ b/rhasspyserver_hermes/__main__.py
@@ -226,6 +226,12 @@ def start_rhasspy() -> None:
     """Create new Rhasspy core and start it."""
     global core
 
+    if core is not None:
+        # Preserve the WS queues since they stay alive across restarts 
+        external_queues = core.message_queues
+    else:
+        external_queues = set()
+
     # Load core
     core = RhasspyCore(
         _ARGS.profile,
@@ -239,6 +245,7 @@ def start_rhasspy() -> None:
         certfile=_ARGS.certfile,
         keyfile=_ARGS.keyfile,
         loop=_LOOP,
+        external_queues= external_queues,
     )
 
     # Add profile settings from the command line


### PR DESCRIPTION
## Problem
While playing around with Rhasspy's websocket API, I noticed that the /api/events/intents endpoint would stop publishing intents when the rhasspy server is restarted.  The websocket stays connected and responds properly to PING requests as if it is still alive except it never sees any of the intents that get processed after the restart.  From the connecting client's perspective it appears as if there are simply no new intents.  Disconnecting and reconnecting the websocket resolves the issue, but there is no indication to the client that the websocket needs to be recreated.

I believe this bug is the root cause of the issues described by a few users here:
https://community.rhasspy.org/t/websocket-closing-on-restarting-rhasspy-issue-with-nodered/2143
https://community.rhasspy.org/t/websockets-not-working-any-more/2601

Its seems they have worked around it by subscribing to the mqtt server instead and abandoning attempts to use the websocket endpoint.

## Cause
When Rhasspy is restarted it recreates the RhasspyCore object which maintains a list of asyncio.queue's responsible for publishing intents to connected websocket clients.  The new RhasspyCore object isn't aware of the old websocket clients and the websocket clients are unaware that a message will never be published to their queues, so they wait indefinitely.

## Proposed Solution
One would expect that either:
 - Websocket clients get disconnected when the server is restarted (eg as a signal to reconnect).
 - Websocket clients get a special message indicating they need to reconnect.
 - The newly created RhasspyCore is made aware of the old websocket clients and continues to publish new intents to them.

 I've opted to go with the last option because it doesn't require any changes to the websocket API, it makes restarts transparent to websocket clients, and it was very easy to implement by passing in the old list of queues to the new RhasspyCore object.

 ## Disclaimer
 I wasn't able to find any contribution guidelines for this project so I made my best attempt at matching code style, naming conventions, etc.  I was able to run these changes on my development machine locally and it seems to work as expected.  If there is a place I can add tests, please let me know.