### PR TITLE
Fix numpy to what networkx==2.4 expects and jinja2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,11 @@ aiohttp==3.7.4
 hypercorn==0.10.1
 multidict==4.7.6
 networkx==2.4
+numpy==1.20.1
 paho-mqtt==1.5.0
 quart==0.11.3
 quart-cors==0.3.0
+markupsafe==2.0.1
 rhasspy-hermes~=0.6.0
 rhasspy-nlu~=0.3.0
 rhasspy-profile~=0.7.0


### PR DESCRIPTION
See https://github.com/rhasspy/rhasspy-remote-http-hermes/pull/5 for details